### PR TITLE
Add `approval_prompt` parameter

### DIFF
--- a/doac/conf.py
+++ b/doac/conf.py
@@ -3,74 +3,74 @@ import datetime
 
 
 class Settings:
-    
+
     def __init__(self, options):
         self.handlers = options.get("HANDLERS", None)
-        
+
         if not self.handlers:
             self.handlers = (
                 "doac.handlers.bearer.BearerHandler",
             )
-        
+
         self.realm = options.get("REALM", "oauth")
-        
+
         self.access_token = options.get("ACCESS_TOKEN", {})
         self.setup_access_token()
-        
+
         self.auth_code = options.get("AUTHORIZATION_CODE", {})
         self.setup_auth_code()
-        
+
         self.auth_token = options.get("AUTHORIZATION_TOKEN", {})
         self.setup_auth_token()
-        
+
         self.client = options.get("CLIENT", {})
         self.setup_client()
-        
+
         self.refresh_token = options.get("REFRESH_TOKEN", {})
         self.setup_refresh_token()
-        
+
     def setup_access_token(self):
         at = self.access_token
         token = {}
-        
+
         token["expires"] = at.get("EXPIRES", datetime.timedelta(hours=2))
         token["length"] = at.get("LENGTH", 100)
-        
+
         self.access_token = token
-    
+
     def setup_auth_code(self):
         ac = self.auth_code
         token = {}
-        
+
         token["expires"] = ac.get("EXPIRES", datetime.timedelta(minutes=15))
         token["length"] = ac.get("LENGTH", 100)
-        
+
         self.auth_code = token
-    
+
     def setup_auth_token(self):
         at = self.auth_token
         token = {}
-        
+
         token["expires"] = at.get("EXPIRES", datetime.timedelta(minutes=15))
         token["length"] = at.get("LENGTH", 100)
-        
+
         self.auth_token = token
-    
+
     def setup_client(self):
         cli = self.client
         client = {}
-        
+
         client["length"] = cli.get("LENGTH", 50)
-        
+
         self.client = client
-    
+
     def setup_refresh_token(self):
         rt = self.refresh_token
         token = {}
-        
+
         token["expires"] = rt.get("EXPIRES", datetime.timedelta(days=60))
         token["length"] = rt.get("LENGTH", 100)
-        
+
         self.refresh_token = token
 
 options_dict = getattr(settings, "OAUTH_CONFIG", {})

--- a/doac/conf.py
+++ b/doac/conf.py
@@ -13,6 +13,7 @@ class Settings:
             )
 
         self.realm = options.get("REALM", "oauth")
+        self.approval_prompt = options.get("APPROVAL_PROMPT", "force")
 
         self.access_token = options.get("ACCESS_TOKEN", {})
         self.setup_access_token()

--- a/doac/exceptions/invalid_request.py
+++ b/doac/exceptions/invalid_request.py
@@ -1,6 +1,10 @@
 from .base import InvalidRequest
 
 
+class ApprovalPromptNotValid(InvalidRequest):
+    reason = "The approval prompt paramter was malformed or invalid."
+
+
 class AuthorizationCodeAlreadyUsed(InvalidRequest):
     reason = "The authorization code was already used to get a refresh token."
 

--- a/doac/managers.py
+++ b/doac/managers.py
@@ -6,86 +6,89 @@ class CustomManager(models.Manager):
     """
     Custom manager that adds functionality for the custom query set.
     """
-    
+
     def __getattr__(self, name):
         """
         Forwards methods called on the manager to its query set.
         """
-        
+
         return getattr(self.get_query_set(), name)
 
 
 class AccessTokenManager(CustomManager):
-    
+
     def get_query_set(self):
         return AccessTokenQuerySet(self.model)
 
 
 class AccessTokenQuerySet(QuerySet):
-    
+
     def for_token(self, token):
         return self.get(token=token)
-    
+
     def is_active(self):
         return self.filter(is_active=True)
-    
+
     def with_client(self, client):
         return self.filter(client=client.id)
-    
+
+    def with_expiration_after(self, date):
+        return self.filter(expires_at__gt=date)
+
     def with_refresh_token(self, refresh_token):
         return self.filter(refresh_token=refresh_token.id)
-    
+
     def with_user(self, user):
         return self.filter(user=user.pk)
 
 
 class AuthorizationCodeManager(CustomManager):
-    
+
     def get_query_set(self):
         return AuthorizationCodeQuerySet(self.model)
 
 
 class AuthorizationCodeQuerySet(QuerySet):
-    
+
     def for_token(self, token):
         return self.get(token=token)
-    
+
     def is_active(self):
         return self.filter(is_active=True)
 
     def with_expiration_before(self, date):
         return self.filter(expires_at__lt=date)
-    
+
     def with_client(self, client):
         return self.filter(client=client.id)
-    
+
     def with_user(self, user):
         return self.filter(user=user.pk)
 
 
 class AuthorizationTokenManager(CustomManager):
-    
+
     def get_query_set(self):
         return AuthorizationTokenQuerySet(self.model)
 
 
 class AuthorizationTokenQuerySet(QuerySet):
-    
+
     def for_token(self, token):
         return self.get(token=token)
-    
+
     def is_active(self):
         return self.filter(is_active=True)
-    
+
     def with_client(self, client):
         return self.filter(client=client.id)
-    
+
     def with_user(self, user):
         return self.filter(user=user.pk)
 
 
 class ClientManager(CustomManager):
-    
+
     def get_query_set(self):
         return ClientQuerySet(self.model)
 
@@ -97,13 +100,13 @@ class ClientQuerySet(QuerySet):
 
     def for_secret(self, secret):
         return self.get(secret=secret)
-    
+
     def is_active(self):
         return self.filter(is_active=True)
 
 
 class RedirectUriManager(CustomManager):
-    
+
     def get_query_set(self):
         return RedirectUriQuerySet(self.model)
 
@@ -118,36 +121,36 @@ class RedirectUriQuerySet(QuerySet):
 
 
 class RefreshTokenManager(CustomManager):
-    
+
     def get_query_set(self):
         return RefreshTokenQuerySet(self.model)
 
 
 class RefreshTokenQuerySet(QuerySet):
-    
+
     def for_token(self, token):
         return self.get(token=token)
-    
+
     def is_active(self):
         return self.filter(is_active=True)
-    
+
     def with_authorization_token(self, authorization_token):
         return self.filter(authorization_token=authorization_token.id)
-    
+
     def with_client(self, client):
         return self.filter(client=client.id)
-    
+
     def with_user(self, user):
         return self.filter(user=user.pk)
 
 
 class ScopeManager(CustomManager):
-    
+
     def get_query_set(self):
         return ScopeQuerySet(self.model)
 
 
 class ScopeQuerySet(QuerySet):
-    
+
     def for_short_name(self, name):
         return self.get(short_name=name)


### PR DESCRIPTION
This adds support to DOAC for the non-standard `approval_prompt` query parameter during authorization and closes #10.
